### PR TITLE
【AudioPlayer-Preview】Editor上で外部の音楽ファイルを再生できる機構の実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 */[Ll]ogs/
 */[Uu]ser[Ss]ettings/
 *.log
+**.idea/
 
 # By default unity supports Blender asset imports, *.blend1 blender files do not need to be commited to version control.
 *.blend1

--- a/project/Assets/Editor.meta
+++ b/project/Assets/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bfee372bd107f234e8748dbb7b3e7c88
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/project/Assets/Editor/Tools.meta
+++ b/project/Assets/Editor/Tools.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5e61a7cf55bb9f74296b218d1aa6df80
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/project/Assets/Editor/Tools/AudioPlayer.meta
+++ b/project/Assets/Editor/Tools/AudioPlayer.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 26e5c45f3cd948e4a954dce2eca8c6a5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/project/Assets/Editor/Tools/AudioPlayer/AudioClipLoader.cs
+++ b/project/Assets/Editor/Tools/AudioPlayer/AudioClipLoader.cs
@@ -1,0 +1,49 @@
+#if UNITY_EDITOR
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using UnityEngine;
+using UnityEngine.Networking;
+
+namespace YukimaruGames.Editor.Tools
+{
+    internal static class AudioClipLoader
+    {
+        private static readonly SemaphoreSlim Semaphore = new(1, 1);
+
+        internal static event Action<float> OnUpdateProgress; 
+        
+        private static float LoadProgress { get; set; }
+
+        internal static string GetUrl(string localFilePath) =>
+            $"file://{localFilePath.Replace("\\", "/")}";
+
+        internal static IEnumerator<AudioClip> Load(string url)
+        {
+            try
+            {
+                Semaphore.Wait(TimeSpan.FromSeconds(5));
+                LoadProgress = 0f;
+            
+                using var www = UnityWebRequestMultimedia.GetAudioClip(url, AudioType.UNKNOWN);
+                www.SendWebRequest();
+                while (!www.isDone)
+                {
+                    LoadProgress = www.downloadProgress;
+                    OnUpdateProgress?.Invoke(LoadProgress);
+                    yield return null;
+                }
+                
+                if (www.result is UnityWebRequest.Result.Success)
+                {
+                    yield return DownloadHandlerAudioClip.GetContent(www);
+                }
+            }
+            finally
+            {
+                Semaphore.Release();
+            }
+        }
+    }
+}
+#endif

--- a/project/Assets/Editor/Tools/AudioPlayer/AudioClipLoader.cs.meta
+++ b/project/Assets/Editor/Tools/AudioPlayer/AudioClipLoader.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 934b1f8aad868e84eb57e842c20f6dfb

--- a/project/Assets/Editor/Tools/AudioPlayer/AudioPlayer.cs
+++ b/project/Assets/Editor/Tools/AudioPlayer/AudioPlayer.cs
@@ -1,0 +1,69 @@
+#if UNITY_EDITOR
+
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace YukimaruGames.Editor.Tools
+{
+    public static class AudioPlayer
+    {
+        private static AudioClip _clip;
+        private static readonly Dictionary<string, AudioClip> AudioClips = new();
+
+        public static bool CanPlay() => _clip != null;
+        
+        public static void Set(string filePath, Action<float> onUpdateProgress)
+        {
+            SafeStop();
+            
+            var url = AudioClipLoader.GetUrl(filePath);
+
+            if (AudioClips.TryGetValue(url, out _clip)) return;
+            
+            AudioClipLoader.OnUpdateProgress += onUpdateProgress;
+            var e = AudioClipLoader.Load(url);
+            while (e.MoveNext())
+            {
+                var current = e.Current;
+                    
+                if (current == null) continue;
+                    
+                AudioClips.TryAdd(url, current);
+                _clip = current;        
+                break;
+            }
+            AudioClipLoader.OnUpdateProgress -= onUpdateProgress;
+        }
+
+        public static void Play()
+        {
+            if (_clip == null)
+            {
+                throw new InvalidOperationException($"Audio clip is null.");
+            }
+
+            InternalAudioUtilProxy.PlayPreviewClip(_clip);
+        }
+
+        public static void Stop()
+        {
+            if (_clip == null)
+            {
+                throw new InvalidOperationException($"Audio clip is null.");
+            }
+            InternalAudioUtilProxy.StopAllPreviewClips();
+        }
+
+        private static void SafeStop()
+        {
+            if (IsPlaying())
+            {
+                Stop();
+            }
+        }
+
+        public static bool IsPlaying() => _clip != null && InternalAudioUtilProxy.IsPreviewClipPlaying(_clip);
+    }
+}
+#endif

--- a/project/Assets/Editor/Tools/AudioPlayer/AudioPlayer.cs.meta
+++ b/project/Assets/Editor/Tools/AudioPlayer/AudioPlayer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a0ce9d75389dbf54981c25f6a11f572f

--- a/project/Assets/Editor/Tools/AudioPlayer/ExternalAudioPlayerWindow.cs
+++ b/project/Assets/Editor/Tools/AudioPlayer/ExternalAudioPlayerWindow.cs
@@ -1,0 +1,169 @@
+#if UNITY_EDITOR
+
+using System;
+using UnityEditor;
+using UnityEngine;
+using System.IO;
+
+namespace YukimaruGames.Editor.Tools
+{
+    public sealed class ExternalAudioPlayerWindow : EditorWindow
+    {
+        // ReSharper disable once InconsistentNaming
+        private const string kToolName = "External Audio Player";
+
+        // ファイル単位で読み込み、事前にロードが完了したAudioを自由にPlay出来る
+        private string _filePath;
+        private bool _isLoading;
+
+        [MenuItem("Tools/" + kToolName)]
+        public static void ShowWindow()
+        {
+            GetWindow<ExternalAudioPlayerWindow>(kToolName);
+        }
+
+        private void OnGUI()
+        {
+            EditorGUILayout.LabelField("Select External Audio File:");
+
+            // ファイルパスの入力フィールドとファイル選択ボタン
+            using (new EditorGUILayout.HorizontalScope())
+            {
+                _filePath = EditorGUILayout.TextField("File Path", _filePath);
+                DrawBrowseButton();
+            }
+
+            DrawLoadButton();
+            DrawHelpBox();
+            using (new EditorGUILayout.HorizontalScope())
+            {
+                DrawPlayButton();
+                DrawStopButton();
+            }
+
+            if (_isLoading)
+            {
+                Repaint();
+            }
+        }
+
+        private void DrawBrowseButton()
+        {
+            if (!GUILayout.Button("Browse", GUILayout.Width(60)))
+            {
+                return;
+            }
+
+            var path = EditorUtility.OpenFilePanel("Select Audio File", "", "mp3,wav,ogg,aiff");
+            if (string.IsNullOrEmpty(path))
+            {
+                return;
+            }
+
+            _filePath = path;
+        }
+
+        private void DrawLoadButton()
+        {
+            using (new EditorGUI.DisabledScope(_isLoading))
+            {
+                if (!GUILayout.Button("Load Audio File"))
+                {
+                    return;
+                }
+            }
+
+            if (!string.IsNullOrEmpty(_filePath) && File.Exists(_filePath))
+            {
+                Load();
+            }
+            else
+            {
+                EditorUtility.DisplayDialog("Error", "Please select a valid audio file.", "OK");
+            }
+        }
+
+        private void DrawHelpBox()
+        {
+            if (!AudioPlayer.CanPlay())
+            {
+                EditorGUILayout.HelpBox("Load an audio file to enable playback controls.", MessageType.Info);
+            }
+        }
+
+        private void DrawPlayButton()
+        {
+            bool isPlay;
+            using (new EditorGUILayout.VerticalScope())
+            {
+                using (new EditorGUI.DisabledScope(!AudioPlayer.CanPlay()))
+                {
+                    isPlay = GUILayout.Button("Play");
+                }
+
+                if (!AudioPlayer.CanPlay())
+                {
+                    EditorGUILayout.HelpBox("No valid audio file set.", MessageType.Error);
+                }
+            }
+
+            if (!isPlay)
+            {
+                return;
+            }
+
+            AudioPlayer.Play();
+        }
+
+        private void DrawStopButton()
+        {
+            bool isStop;
+            using (new EditorGUILayout.VerticalScope())
+            {
+                using (new EditorGUI.DisabledScope(!AudioPlayer.IsPlaying()))
+                {
+                    isStop = GUILayout.Button("Stop");
+                }
+
+                if (!AudioPlayer.IsPlaying())
+                {
+                    EditorGUILayout.HelpBox("No audio playing.", MessageType.Warning);
+                }
+            }
+
+            if (!isStop)
+            {
+                return;
+            }
+
+            AudioPlayer.Stop();
+        }
+
+        private void Load()
+        {
+            try
+            {
+                _isLoading = true;
+                AudioPlayer.Set(_filePath, UpdateLoadProgress);
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+                throw;
+            }
+            finally
+            {
+                _isLoading = false;
+                EditorUtility.ClearProgressBar();
+
+            }
+        }
+
+        private void UpdateLoadProgress(float progress) =>
+            EditorUtility.DisplayProgressBar(
+                "Loading...",
+                $"{progress * 100:F1}/100.0%",
+                progress);
+    }
+}
+#endif

--- a/project/Assets/Editor/Tools/AudioPlayer/ExternalAudioPlayerWindow.cs.meta
+++ b/project/Assets/Editor/Tools/AudioPlayer/ExternalAudioPlayerWindow.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 70a5c13dfc6fa544682bd4763287c1f0

--- a/project/Assets/Editor/Tools/AudioPlayer/InternalAudioUtilProxy.cs
+++ b/project/Assets/Editor/Tools/AudioPlayer/InternalAudioUtilProxy.cs
@@ -1,0 +1,79 @@
+#if UNITY_EDITOR
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using UnityEngine;
+
+namespace YukimaruGames.Editor.Tools
+{
+    /// <see cref=" https://qiita.com/Rijicho_nl/items/c7e6a5cb9cf56e52588a "/>
+    internal static class InternalAudioUtilProxy
+    {
+        private static readonly Lazy<Type> AudioUtilType =
+            new(typeof(UnityEditor.Editor).Assembly.GetType("UnityEditor.AudioUtil"));
+
+        private static readonly ConcurrentDictionary<string, Func<object[], object>> CompiledMethods = new();
+
+        // ReSharper disable once InconsistentNaming
+        private const BindingFlags kBindingFlags =
+            BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.GetField |
+            BindingFlags.GetProperty | BindingFlags.InvokeMethod;
+
+        public static void PlayPreviewClip(AudioClip clip) => Call(nameof(PlayPreviewClip), clip, 0, false);
+        public static void StopAllPreviewClips() => Call(nameof(StopAllPreviewClips));
+        public static void PausePreviewClip() => Call(nameof(PausePreviewClip));
+        public static bool IsPreviewClipPlaying(AudioClip clip) => Call<bool, AudioClip>(nameof(IsPreviewClipPlaying), clip);
+        public static float GetClipPosition(AudioClip clip) => Call<float, AudioClip>(nameof(GetClipPosition), clip);
+        // ないかも？
+        public static void SetClipPosition(AudioClip clip, float position) =>
+            Call(nameof(SetClipPosition), clip, position);
+        public static int GetClipSamplePosition(AudioClip clip) =>
+            Call<int, AudioClip>(nameof(GetClipSamplePosition), clip);
+        public static void SetClipSamplePosition(AudioClip clip, int position) =>
+            Call(nameof(SetClipSamplePosition), clip, position);
+        
+        private static Func<object[], object> GetOrCompile(string methodName) =>
+            CompiledMethods.GetOrAdd(methodName, m =>
+            {
+                var mi2Method = AudioUtilType.Value.GetMethod(m, kBindingFlags);
+
+                var args = Expression.Parameter(typeof(object[]), "args");
+                var parameters = mi2Method!.GetParameters()
+                    .Select((p, idx) =>
+                        (Expression)Expression.Convert(Expression.ArrayIndex(args, Expression.Constant(idx)),
+                            p.ParameterType))
+                    .ToArray();
+
+                var lambda = Expression.Lambda<Func<object[], object>>(
+                    mi2Method.ReturnType == typeof(void)
+                        ? Expression.Block(Expression.Call(null, mi2Method, parameters),
+                            Expression.Call(null, mi2Method, parameters),
+                            Expression.Constant(null, typeof(object))
+                        )
+                        : Expression.Convert(
+                            Expression.Call(null, mi2Method, parameters),
+                            typeof(object)),
+                    args);
+                return lambda.Compile();
+            });
+
+        private static TResult Call<TResult>(string methodName) => (TResult)GetOrCompile(methodName).Invoke(null);
+        private static TResult Call<TResult, T1>(string methodName, T1 arg1) =>
+            (TResult)GetOrCompile(methodName).Invoke(new object[] { arg1 });
+        private static TResult Call<TResult, T1, T2>(string methodName, T1 arg1, T2 arg2) =>
+            (TResult)GetOrCompile(methodName).Invoke(new object[] { arg1, arg2 });
+        private static TResult Call<TResult, T1, T2, T3>(string methodName, T1 arg1, T2 arg2, T3 arg3) =>
+            (TResult)GetOrCompile(methodName).Invoke(new object[] { arg1, arg2, arg3 });
+
+        private static void Call(string methodName) => GetOrCompile(methodName).Invoke(null);
+        private static void Call<T1>(string methodName, T1 arg1) =>
+            GetOrCompile(methodName).Invoke(new object[] { arg1 });
+        private static void Call<T1, T2>(string methodName, T1 arg1, T2 arg2) =>
+            GetOrCompile(methodName).Invoke(new object[] { arg1, arg2 });
+        private static void Call<T1, T2, T3>(string methodName, T1 arg1, T2 arg2, T3 arg3) =>
+            GetOrCompile(methodName).Invoke(new object[] { arg1, arg2, arg3 });
+    }
+}
+#endif

--- a/project/Assets/Editor/Tools/AudioPlayer/InternalAudioUtilProxy.cs.meta
+++ b/project/Assets/Editor/Tools/AudioPlayer/InternalAudioUtilProxy.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 60d84177950d22b4aab895b524815d50

--- a/project/Assets/Editor/Tools/AudioPlayer/YukimaruGames.Editor.Tools.AudioPlayer.asmdef
+++ b/project/Assets/Editor/Tools/AudioPlayer/YukimaruGames.Editor.Tools.AudioPlayer.asmdef
@@ -1,0 +1,16 @@
+{
+    "name": "YukimaruGames.Editor.Tools.AudioPlayer",
+    "rootNamespace": "YukimaruGames.Editor.Tools",
+    "references": [],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": false,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/project/Assets/Editor/Tools/AudioPlayer/YukimaruGames.Editor.Tools.AudioPlayer.asmdef.meta
+++ b/project/Assets/Editor/Tools/AudioPlayer/YukimaruGames.Editor.Tools.AudioPlayer.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: fb883c48b48a97a4b8d79b73b0ad90fb
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# Overview

Editor上で外部ファイルをAudioClipとして読み込み「Play」モードでなくても再生できる機能。


# Implements

![ExternalAudioPlayer](https://github.com/user-attachments/assets/d209850a-2327-4fa7-8b5b-5c0bca91a345)

# TODO

* 再生はできるが止められない。
* 音量の変更はできない。
* Unity-2022以降メソッドの名前が変更された。

AudioUtilを利用した実装では実現できない機能が多いため実装方法を見直す必要あり。

#Remarks

* https://qiita.com/Rijicho_nl/items/c7e6a5cb9cf56e52588a
* https://www.hanachiru-blog.com/entry/2022/09/22/120000